### PR TITLE
Missing args to InstanceCreate

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -117,7 +117,7 @@ func (c *Cluster) ensureClusterExists(ctx context.Context, timeoutMinutes int) (
 		}
 		pubkeyList = append(pubkeyList, string(pub))
 		// add the public key to the node in addition to the user one
-		instances, err := c.createControlPlaneNodes(ctx, true, 1, highest, controlPlaneIP.Ip, "", pubkeyList, controlPlanePrefix, controlPlaneImage.Name, memoryGB, cpuCount)
+		instances, err := c.createControlPlaneNodes(ctx, true, 1, highest, controlPlaneIP, "", pubkeyList, controlPlanePrefix, controlPlaneImage.Name, memoryGB, cpuCount)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create control plane node: %w", err)
 		}
@@ -127,7 +127,6 @@ func (c *Cluster) ensureClusterExists(ctx context.Context, timeoutMinutes int) (
 		hostid := instances[0].Id
 		ipList, err := client.InstanceExternalIpList(ctx, oxide.InstanceExternalIpListParams{
 			Instance: oxide.NameOrId(hostid),
-			Project:  oxide.NameOrId(projectID),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get external IP list: %w", err)
@@ -207,7 +206,7 @@ func (c *Cluster) ensureClusterExists(ctx context.Context, timeoutMinutes int) (
 	count := controlPlaneCount - len(controlPlaneNodes)
 	c.logger.Debugf("control plane nodes %d, desired %d, creating %d", len(controlPlaneNodes), controlPlaneCount, count)
 
-	if _, err := c.createControlPlaneNodes(ctx, false, count, highest, controlPlaneIP.Ip, joinToken, []string{string(c.userPubkey)}, controlPlanePrefix, controlPlaneImage.Name, memoryGB, cpuCount); err != nil {
+	if _, err := c.createControlPlaneNodes(ctx, false, count, highest, nil, joinToken, []string{string(c.userPubkey)}, controlPlanePrefix, controlPlaneImage.Name, memoryGB, cpuCount); err != nil {
 		return nil, fmt.Errorf("failed to create control plane node: %w", err)
 	}
 

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -8,19 +8,36 @@ import (
 	"github.com/oxidecomputer/oxide.go/oxide"
 )
 
-func CreateInstance(ctx context.Context, client *oxide.Client, projectID, name, image string, memoryGB, cpuCount int, cloudConfig string) (*oxide.Instance, error) {
+func CreateInstance(ctx context.Context, client *oxide.Client, projectID, name, image string, memoryGB, cpuCount int, cloudConfig string, floatingIp *oxide.FloatingIp) (*oxide.Instance, error) {
+	externalIps := []oxide.ExternalIpCreate{}
+	if floatingIp != nil {
+		externalIps = append(externalIps, oxide.ExternalIpCreate{
+			Type:       oxide.ExternalIpCreateTypeFloating,
+			FloatingIp: oxide.NameOrId(floatingIp.Id),
+		})
+	}
 	return client.InstanceCreate(ctx, oxide.InstanceCreateParams{
 		Project: oxide.NameOrId(projectID),
 		Body: &oxide.InstanceCreate{
-			Name:   oxide.Name(name),
-			Memory: oxide.ByteCount(memoryGB * GB),
-			Ncpus:  oxide.InstanceCpuCount(cpuCount),
+			Name:        oxide.Name(name),
+			Description: name,
+			Hostname:    oxide.Hostname(name),
+			Memory:      oxide.ByteCount(memoryGB * GB),
+			Ncpus:       oxide.InstanceCpuCount(cpuCount),
+			ExternalIps: externalIps,
 			BootDisk: &oxide.InstanceDiskAttachment{
+				Type: "create",
 				DiskSource: oxide.DiskSource{
 					Type:      oxide.DiskSourceTypeImage,
 					ImageId:   image,
-					BlockSize: blockSize, // TODO: Must be multiple of image size. Verify?
+					BlockSize: blockSize,
 				},
+				Size:        oxide.ByteCount(3 * GB), // FIXME, use explicit disk size
+				Name:        oxide.Name(name),
+				Description: name,
+			},
+			NetworkInterfaces: oxide.InstanceNetworkInterfaceAttachment{
+				Type: "default",
 			},
 			UserData: cloudConfig,
 		},
@@ -68,15 +85,15 @@ runcmd:
 }
 
 // createControlPlaneNodes creates new control plane nodes
-func (c *Cluster) createControlPlaneNodes(ctx context.Context, initCluster bool, count, start int, controlPlaneIP string, joinToken string, pubkey []string, prefix string, image string, memoryGB, cpuCount int) ([]oxide.Instance, error) {
+func (c *Cluster) createControlPlaneNodes(ctx context.Context, initCluster bool, count, start int, controlPlaneIP *oxide.FloatingIp, joinToken string, pubkey []string, prefix string, image string, memoryGB, cpuCount int) ([]oxide.Instance, error) {
 	var controlPlaneNodes []oxide.Instance
 	c.logger.Debugf("Creating %d control plane nodes with prefix %s", count, prefix)
-	cloudConfig, err := GenerateCloudConfig("server", initCluster, controlPlaneIP, joinToken, pubkey)
+	cloudConfig, err := GenerateCloudConfig("server", initCluster, controlPlaneIP.Ip, joinToken, pubkey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate cloud config: %w", err)
 	}
 	for i := start; i < count; i++ {
-		instance, err := CreateInstance(ctx, c.client, c.projectID, fmt.Sprintf("%s%d", prefix, i), image, memoryGB, cpuCount, cloudConfig)
+		instance, err := CreateInstance(ctx, c.client, c.projectID, fmt.Sprintf("%s%d", prefix, i), image, memoryGB, cpuCount, cloudConfig, controlPlaneIP)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create control plane node: %w", err)
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -81,7 +81,7 @@ func (s *Server) handleAddNode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.logger.Printf("Creating worker node: %s", workerName)
-	if _, err := cluster.CreateInstance(ctx, s.oxideClient, s.projectID, workerName, s.workerImage, s.workerMemoryGB, s.workerCPUCount, cloudConfig); err != nil {
+	if _, err := cluster.CreateInstance(ctx, s.oxideClient, s.projectID, workerName, s.workerImage, s.workerMemoryGB, s.workerCPUCount, cloudConfig, nil); err != nil {
 		s.logger.Debugf("Failed to create worker node: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Add all required arguments to InstanceCreate invocation.

TODO: needs disk/image size (should be resolved with image id issue).

FloatingIP is only given to the first control plane node.