### PR TITLE
default no ephemeral IP for worker nodes, controllable via CLI flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,8 @@ func rootCmd() (*cobra.Command, error) {
 		controlPlaneSecret      string
 		verbose                 int
 		address                 string
+		workerExternalIP        bool
+		controlPlaneExternalIP  bool
 
 		logger = log.New()
 	)
@@ -105,8 +107,8 @@ func rootCmd() (*cobra.Command, error) {
 
 			c := cluster.New(logentry, oxideClient, clusterProject,
 				controlPlanePrefix, controlPlaneCount,
-				cluster.NodeSpec{Image: cluster.Image{Name: controlPlaneImageName, Source: controlPlaneImageSource}, MemoryGB: int(controlPlaneMemory), CPUCount: int(controlPlaneCPU)},
-				cluster.NodeSpec{Image: cluster.Image{Name: workerImageName, Source: workerImageSource}, MemoryGB: int(workerMemory), CPUCount: int(workerCPU)},
+				cluster.NodeSpec{Image: cluster.Image{Name: controlPlaneImageName, Source: controlPlaneImageSource}, MemoryGB: int(controlPlaneMemory), CPUCount: int(controlPlaneCPU), ExternalIP: controlPlaneExternalIP},
+				cluster.NodeSpec{Image: cluster.Image{Name: workerImageName, Source: workerImageSource}, MemoryGB: int(workerMemory), CPUCount: int(workerCPU), ExternalIP: workerExternalIP},
 				controlPlaneSecret, kubeconfig, pubkey,
 			)
 			logentry.Debugf("Ensuring project exists: %s", clusterProject)
@@ -151,6 +153,8 @@ func rootCmd() (*cobra.Command, error) {
 	cmd.Flags().StringVar(&kubeconfigPath, "kubeconfig", "~/.kube/oxide-controller-config", "Path to save kubeconfig when generating new cluster, or to use for accessing existing cluster")
 	cmd.Flags().BoolVar(&kubeconfigOverwrite, "kubeconfig-overwrite", false, "Whether or not to override the kubeconfig file if it already exists and a new cluster is created")
 	cmd.Flags().StringVar(&controlPlaneSecret, "control-plane-secret", "kube-system/oxide-controller-secret", "secret in Kubernetes cluster where the following are stored: join token, user ssh public key, controller ssh private/public keypair; should be as <namespace>/<name>")
+	cmd.Flags().BoolVar(&workerExternalIP, "worker-external-ip", false, "Whether or not to assign an ephemeral public IP to the worker nodes, useful for debugging")
+	cmd.Flags().BoolVar(&controlPlaneExternalIP, "control-plane-external-ip", true, "Whether or not to assign an ephemeral public IP to the control plane nodes, needed to access cluster from outside sled, as well as for debugging")
 	cmd.Flags().IntVarP(&verbose, "verbose", "v", 0, "set log level, 0 is info, 1 is debug, 2 is trace")
 	cmd.Flags().StringVar(&address, "address", ":8080", "Address to bind the server to")
 

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -11,7 +11,7 @@ import (
 )
 
 func CreateInstance(ctx context.Context, client *oxide.Client, projectID, instanceName string, spec NodeSpec, cloudConfig string) (*oxide.Instance, error) {
-	return client.InstanceCreate(ctx, oxide.InstanceCreateParams{
+	params := oxide.InstanceCreateParams{
 		Project: oxide.NameOrId(projectID),
 		Body: &oxide.InstanceCreate{
 			Name:        oxide.Name(instanceName),
@@ -30,17 +30,20 @@ func CreateInstance(ctx context.Context, client *oxide.Client, projectID, instan
 				Name:        oxide.Name(instanceName),
 				Description: instanceName,
 			},
-			ExternalIps: []oxide.ExternalIpCreate{
-				{
-					Type: oxide.ExternalIpCreateTypeEphemeral,
-				},
-			},
 			NetworkInterfaces: oxide.InstanceNetworkInterfaceAttachment{
 				Type: "default",
 			},
 			UserData: cloudConfig,
 		},
-	})
+	}
+	if spec.ExternalIP {
+		params.Body.ExternalIps = []oxide.ExternalIpCreate{
+			{
+				Type: oxide.ExternalIpCreateTypeEphemeral,
+			},
+		}
+	}
+	return client.InstanceCreate(ctx, params)
 }
 
 // GenerateCloudConfig for a particular node type

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -2,10 +2,11 @@ package cluster
 
 // Node represents a Kubernetes node
 type NodeSpec struct {
-	Image    Image `json:"image"`
-	MemoryGB int   `json:"memoryGB"`
-	CPUCount int   `json:"cpuCount"`
-	DiskSize int   `json:"diskSize"`
+	Image      Image `json:"image"`
+	MemoryGB   int   `json:"memoryGB"`
+	CPUCount   int   `json:"cpuCount"`
+	DiskSize   int   `json:"diskSize"`
+	ExternalIP bool  `json:"externalIP"`
 }
 
 type Image struct {


### PR DESCRIPTION
Fixes #16 

Instead of getting rid of it entirely, it creates defaults, which you can override via CLI flags. By default:

- control plane nodes _do_ have ephemeral external IP
- worker nodes _do not_ have ephemeral external IP