### PR TITLE
add support for long-running control management, option to disable it, control loop timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # oxide-controller
 
-This is the server that controls the Ainekko stack deployment on an Oxide sled. It serves two purposes:
+This is the server that controls the Ainekko stack deployment on an Oxide sled. It serves these purposes:
 
-1. It provides a REST API for the Ainekko stack, to enable users to interact with the sled, adding or removing VMs to act as workers.
-1. It provides a loop that checks the state of the cluster and keeps it alive.
+1. It ensures a Kubernetes cluster is running on the sled, providing a loop that checks the state of the cluster and keeps it alive.
+1. It provides a REST API for the Ainekko stack, to enable users to interact with the sled, changing the worker VM count.
 
 This can run standalone on your own device, in a VM, or inside the Kubernetes cluster itself.
 
@@ -14,6 +14,18 @@ The production-recommended way to run this is:
 1. Run this locally, pointing to the Oxide sled, which will cause a 3-node kubernetes cluster to be deployed.
 1. Stop running this locally, deploy it as a `StatefulSet` of 1 replica in the Kubernetes cluster.
 1. Profit!
+
+In the future, the oxide-controller will pivot automatically to deploying itself on the cluster
+and shutting down the local instance.
+
+## REST API
+
+The REST API is fairly simple, with the following endpoints:
+
+- `GET /nodes/workers` - get the targeted count of worker nodes
+- `POST /nodes/workers/modify` - modify the targeted count of worker nodes. Content-Type should be `application/text`, body should just be the new count.
+
+## ssh Keys
 
 The oxide-controller uses two ssh keys:
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/pkg/cluster/exec.go
+++ b/pkg/cluster/exec.go
@@ -7,7 +7,13 @@ import (
 	"github.com/aifoundry-org/oxide-controller/pkg/util"
 )
 
-func (c *Cluster) Initialize(ctx context.Context, timeoutMinutes int, kubeconfig []byte, kubeconfigOverwrite bool) (newKubeconfig []byte, err error) {
+// Execute execute the core functionality, which includes:
+// 1. Verifying the project exists
+// 2. Verifying the images exist
+// 3. Verifying the cluster exists
+// 4. Ensuring the worker nodes are created as desired
+// 5. Returning the new kubeconfig, if any
+func (c *Cluster) Execute(ctx context.Context, timeoutMinutes int, kubeconfig []byte, kubeconfigOverwrite bool) (newKubeconfig []byte, err error) {
 
 	projectID, err := ensureProjectExists(ctx, c.logger, c.client, c.projectID)
 	if err != nil {
@@ -37,7 +43,7 @@ func (c *Cluster) Initialize(ctx context.Context, timeoutMinutes int, kubeconfig
 	}
 
 	// ensure worker nodes as desired
-	if _, err := c.CreateWorkerNodes(ctx, c.workerCount); err != nil {
+	if _, err := c.CreateWorkerNodes(ctx, c.workerCount.Load()); err != nil {
 		return nil, fmt.Errorf("failed to create worker nodes: %v", err)
 	}
 	return newKubeconfig, nil

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -158,7 +158,7 @@ func (c *Cluster) CreateControlPlaneNodes(ctx context.Context, initCluster bool,
 }
 
 // CreateWorkerNodes creates new worker nodes
-func (c *Cluster) CreateWorkerNodes(ctx context.Context, count int) ([]oxide.Instance, error) {
+func (c *Cluster) CreateWorkerNodes(ctx context.Context, count uint32) ([]oxide.Instance, error) {
 	var nodes []oxide.Instance
 	c.logger.Debugf("Creating %d worker nodes with prefix %s", count, c.prefix)
 	joinToken, err := c.GetJoinToken(ctx)
@@ -178,7 +178,7 @@ func (c *Cluster) CreateWorkerNodes(ctx context.Context, count int) ([]oxide.Ins
 		return nil, fmt.Errorf("failed to generate cloud config: %w", err)
 	}
 
-	for i := 0; i < count; i++ {
+	for i := 0; i < int(count); i++ {
 		workerName := fmt.Sprintf("worker-%d", time.Now().Unix())
 		instance, err := CreateInstance(ctx, c.client, c.projectID, workerName, c.workerSpec, cloudConfig)
 		if err != nil {
@@ -188,4 +188,15 @@ func (c *Cluster) CreateWorkerNodes(ctx context.Context, count int) ([]oxide.Ins
 	}
 	c.logger.Debugf("Created %d control plane nodes with prefix %s", count, c.prefix)
 	return nodes, nil
+}
+
+// ModifyWorkerNodeCount modifies the number of worker nodes in the cluster
+func (c *Cluster) ModifyWorkerNodeCount(count uint32) (uint32, error) {
+	c.workerCount.Store(count)
+	return c.workerCount.Load(), nil
+}
+
+// GetWorkerNodeCount gets the number of worker nodes in the cluster
+func (c *Cluster) GetWorkerNodeCount() (uint32, error) {
+	return c.workerCount.Load(), nil
 }


### PR DESCRIPTION
Also has option for `run-once`, so it will run once and exit.

Currently all changes are in memory, so the following flow will not work as expected:

1. Start with worker count 3
2. Call REST API to change worker count to 5 (or any other number)
3. Stop and restart the server
4. Worker count is reset to 3

In the future, we will change it to persist the targeted count in a `ConfigMap`