### PR TITLE
switch from creating worker nodes to ensuring specific count

### DIFF
--- a/pkg/cluster/const.go
+++ b/pkg/cluster/const.go
@@ -11,4 +11,5 @@ const (
 	secretKeyJoinToken        = "k3s-join-token"
 	secretKeySystemSSHPublic  = "system-ssh-public-key"
 	secretKeySystemSSHPrivate = "system-ssh-private-key"
+	secretKeyWorkerCount      = "worker-count"
 )

--- a/pkg/cluster/exec.go
+++ b/pkg/cluster/exec.go
@@ -11,9 +11,9 @@ import (
 // 1. Verifying the project exists
 // 2. Verifying the images exist
 // 3. Verifying the cluster exists
-// 4. Ensuring the worker nodes are created as desired
+// 4. Ensuring the worker nodes exist as desired
 // 5. Returning the new kubeconfig, if any
-func (c *Cluster) Execute(ctx context.Context, timeoutMinutes int, kubeconfig []byte, kubeconfigOverwrite bool) (newKubeconfig []byte, err error) {
+func (c *Cluster) Execute(ctx context.Context) (newKubeconfig []byte, err error) {
 
 	projectID, err := ensureProjectExists(ctx, c.logger, c.client, c.projectID)
 	if err != nil {
@@ -37,13 +37,13 @@ func (c *Cluster) Execute(ctx context.Context, timeoutMinutes int, kubeconfig []
 	c.workerSpec.Image = images[1]
 	c.workerSpec.DiskSize = util.RoundUp(images[0].Size, GB)
 
-	newKubeconfig, err = c.ensureClusterExists(ctx, timeoutMinutes, kubeconfig, kubeconfigOverwrite)
+	newKubeconfig, err = c.ensureClusterExists(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("cluster verification failed: %v", err)
 	}
 
 	// ensure worker nodes as desired
-	if _, err := c.CreateWorkerNodes(ctx, c.workerCount.Load()); err != nil {
+	if _, err := c.EnsureWorkerNodes(ctx); err != nil {
 		return nil, fmt.Errorf("failed to create worker nodes: %v", err)
 	}
 	return newKubeconfig, nil

--- a/pkg/cluster/project.go
+++ b/pkg/cluster/project.go
@@ -22,8 +22,8 @@ func ensureProjectExists(ctx context.Context, logger *log.Entry, client *oxide.C
 
 	var projectID string
 	for _, project := range projects.Items {
-		logger.Tracef("Checking project %s vs desired %s", project.Name, projectName)
-		if string(project.Name) == projectName {
+		logger.Tracef("Checking project %s %s vs desired %s", project.Name, project.Id, projectName)
+		if string(project.Name) == projectName || project.Id == projectName {
 			logger.Infof("Cluster project '%s' exists.", projectName)
 			projectID = project.Id
 			logger.Infof("Using project '%s' with ID '%s'", projectName, projectID)


### PR DESCRIPTION
This is a deep rewrite of many of the things around cluster creation and management.

* the request to create worker nodes was creating new nodes of desired count, rather than ensuring the count is achieved
* stores all of the `Execute()` parameters in the `struct Cluster`, which makes it cleaner (although `Cluster.New()` needs rewriting to pass simpler parameters, like an opts object; future)
* checks the actual worker nodes in the cluster before creating
* fixes an issue wherein the prefix for workers was not saved or checked, and adds prefix for them as distinct from control plane prefix
* stores the desired worker count _inside_ the cluster in the secret. This means that when you start it again, it finds them and checks there, rather than starting from scratch.

These all are good on their own, but especially prepping to run this inside the cluster.