### PR TITLE
optionally create extra disk

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,35 +24,37 @@ const (
 
 func rootCmd() (*cobra.Command, error) {
 	var (
-		oxideAPIURL                string
-		tokenFilePath              string
-		clusterProject             string
-		controlPlanePrefix         string
-		workerPrefix               string
-		controlPlaneCount          uint
-		workerCount                uint
-		controlPlaneImageName      string
-		controlPlaneImageSource    string
-		workerImageName            string
-		workerImageSource          string
-		controlPlaneMemory         uint64
-		workerMemory               uint64
-		controlPlaneCPU            uint16
-		workerCPU                  uint16
-		clusterInitWait            int
-		userSSHPublicKey           string
-		kubeconfigPath             string
-		kubeconfigOverwrite        bool
-		controlPlaneSecret         string
-		verbose                    int
-		address                    string
-		workerExternalIP           bool
-		controlPlaneExternalIP     bool
-		controlLoopMins            int
-		runOnce                    bool
-		controlPlaneImageBlocksize int
-		workerImageBlocksize       int
-		imageParallelism           int
+		oxideAPIURL                 string
+		tokenFilePath               string
+		clusterProject              string
+		controlPlanePrefix          string
+		workerPrefix                string
+		controlPlaneCount           uint
+		workerCount                 uint
+		controlPlaneImageName       string
+		controlPlaneImageSource     string
+		workerImageName             string
+		workerImageSource           string
+		controlPlaneMemory          uint64
+		workerMemory                uint64
+		controlPlaneCPU             uint16
+		workerCPU                   uint16
+		clusterInitWait             int
+		userSSHPublicKey            string
+		kubeconfigPath              string
+		kubeconfigOverwrite         bool
+		controlPlaneSecret          string
+		verbose                     int
+		address                     string
+		workerExternalIP            bool
+		controlPlaneExternalIP      bool
+		controlLoopMins             int
+		runOnce                     bool
+		controlPlaneImageBlocksize  int
+		workerImageBlocksize        int
+		imageParallelism            int
+		workerExtraDiskSizeGB       uint
+		controlPlaneExtraDiskSizeGB uint
 
 		logger = log.New()
 	)
@@ -116,8 +118,8 @@ func rootCmd() (*cobra.Command, error) {
 
 			c := cluster.New(logentry, oxideClient, clusterProject,
 				controlPlanePrefix, workerPrefix, int(controlPlaneCount), int(workerCount),
-				cluster.NodeSpec{Image: cluster.Image{Name: controlPlaneImageName, Source: controlPlaneImageSource, Blocksize: controlPlaneImageBlocksize}, MemoryGB: int(controlPlaneMemory), CPUCount: int(controlPlaneCPU), ExternalIP: controlPlaneExternalIP},
-				cluster.NodeSpec{Image: cluster.Image{Name: workerImageName, Source: workerImageSource, Blocksize: workerImageBlocksize}, MemoryGB: int(workerMemory), CPUCount: int(workerCPU), ExternalIP: workerExternalIP},
+				cluster.NodeSpec{Image: cluster.Image{Name: controlPlaneImageName, Source: controlPlaneImageSource, Blocksize: controlPlaneImageBlocksize}, MemoryGB: int(controlPlaneMemory), CPUCount: int(controlPlaneCPU), ExternalIP: controlPlaneExternalIP, ExtraDiskSize: int(controlPlaneExtraDiskSizeGB * cluster.GB)},
+				cluster.NodeSpec{Image: cluster.Image{Name: workerImageName, Source: workerImageSource, Blocksize: workerImageBlocksize}, MemoryGB: int(workerMemory), CPUCount: int(workerCPU), ExternalIP: workerExternalIP, ExtraDiskSize: int(workerExtraDiskSizeGB * cluster.GB)},
 				imageParallelism,
 				controlPlaneSecret, kubeconfig, pubkey,
 				time.Duration(clusterInitWait)*time.Minute,
@@ -198,6 +200,8 @@ func rootCmd() (*cobra.Command, error) {
 	cmd.Flags().StringVar(&workerImageName, "worker-image-name", "debian-12-cloud", "Image to use for worker nodes")
 	cmd.Flags().IntVar(&workerImageBlocksize, "worker-image-blocksize", defaultBlocksize, "Blocksize to use for worker images")
 	cmd.Flags().StringVar(&workerImageSource, "worker-image-source", "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.raw", "Image to use for worker instances")
+	cmd.Flags().UintVar(&workerExtraDiskSizeGB, "worker-extra-disk-size", 0, "Size of extra disk to attach to worker nodes, in GB. Leave as 0 for no extra disk.")
+	cmd.Flags().UintVar(&controlPlaneExtraDiskSizeGB, "control-plane-extra-disk-size", 0, "Size of extra disk to attach to control plane nodes, in GB. Leave as 0 for no extra disk.")
 	cmd.Flags().Uint64Var(&controlPlaneMemory, "control-plane-memory", 4, "Memory to allocate to each control plane node, in GB")
 	cmd.Flags().UintVar(&workerCount, "worker-count", 0, "Number of worker instances to create on startup and maintain, until changed via API")
 	cmd.Flags().Uint64Var(&workerMemory, "worker-memory", 16, "Memory to allocate to each worker node, in GB")

--- a/pkg/cluster/exec.go
+++ b/pkg/cluster/exec.go
@@ -33,9 +33,9 @@ func (c *Cluster) Execute(ctx context.Context) (newKubeconfig []byte, err error)
 	}
 	c.logger.Infof("images %v", images)
 	c.controlPlaneSpec.Image = images[0]
-	c.controlPlaneSpec.DiskSize = util.RoundUp(images[0].Size, GB)
+	c.controlPlaneSpec.RootDiskSize = util.RoundUp(images[0].Size, GB)
 	c.workerSpec.Image = images[1]
-	c.workerSpec.DiskSize = util.RoundUp(images[0].Size, GB)
+	c.workerSpec.RootDiskSize = util.RoundUp(images[0].Size, GB)
 
 	newKubeconfig, err = c.ensureClusterExists(ctx)
 	if err != nil {

--- a/pkg/cluster/node_test.go
+++ b/pkg/cluster/node_test.go
@@ -10,10 +10,11 @@ func TestGenerateCloudConfig(t *testing.T) {
 		controlPlaneIP string
 		joinToken      string
 		pubkey         []string
+		extraDisk      string
 		expected       string
 		err            error
 	}{
-		{"server-init-pubkey", "server", true, "10.0.0.5", "joinme", []string{"somekey"}, `#cloud-config
+		{"server-init-pubkey", "server", true, "10.0.0.5", "joinme", []string{"somekey"}, "", `#cloud-config
 runcmd:
   - |
     PRIVATE_IP=$(hostname -I | awk '{print $1}')
@@ -28,7 +29,7 @@ ssh_pwauth: false
 disable_root: false
 allow_public_ssh_keys: true
 `, nil},
-		{"server-init-nopubkey", "server", true, "10.0.0.5", "joinme", nil, `#cloud-config
+		{"server-init-nopubkey", "server", true, "10.0.0.5", "joinme", nil, "", `#cloud-config
 runcmd:
   - |
     PRIVATE_IP=$(hostname -I | awk '{print $1}')
@@ -38,7 +39,7 @@ ssh_pwauth: false
 disable_root: false
 allow_public_ssh_keys: true
 `, nil},
-		{"server-join-pubkey", "server", false, "10.0.0.5", "joinme", []string{"somekey"}, `#cloud-config
+		{"server-join-pubkey", "server", false, "10.0.0.5", "joinme", []string{"somekey"}, "", `#cloud-config
 runcmd:
   - |
     PRIVATE_IP=$(hostname -I | awk '{print $1}')
@@ -53,7 +54,7 @@ ssh_pwauth: false
 disable_root: false
 allow_public_ssh_keys: true
 `, nil},
-		{"server-join-nopubkey", "server", false, "10.0.0.5", "joinme", nil, `#cloud-config
+		{"server-join-nopubkey", "server", false, "10.0.0.5", "joinme", nil, "", `#cloud-config
 runcmd:
   - |
     PRIVATE_IP=$(hostname -I | awk '{print $1}')
@@ -63,7 +64,7 @@ ssh_pwauth: false
 disable_root: false
 allow_public_ssh_keys: true
 `, nil},
-		{"agent-pubkey", "agent", false, "10.0.0.5", "joinme", []string{"somekey"}, `#cloud-config
+		{"agent-pubkey", "agent", false, "10.0.0.5", "joinme", []string{"somekey"}, "", `#cloud-config
 runcmd:
   - |
     PRIVATE_IP=$(hostname -I | awk '{print $1}')
@@ -78,7 +79,7 @@ ssh_pwauth: false
 disable_root: false
 allow_public_ssh_keys: true
 `, nil},
-		{"agent-nopubkey", "agent", false, "10.0.0.5", "joinme", nil, `#cloud-config
+		{"agent-nopubkey", "agent", false, "10.0.0.5", "joinme", nil, "", `#cloud-config
 runcmd:
   - |
     PRIVATE_IP=$(hostname -I | awk '{print $1}')
@@ -92,7 +93,7 @@ allow_public_ssh_keys: true
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := GenerateCloudConfig(tt.nodeType, tt.initCluster, tt.controlPlaneIP, tt.joinToken, tt.pubkey)
+			result, err := GenerateCloudConfig(tt.nodeType, tt.initCluster, tt.controlPlaneIP, tt.joinToken, tt.pubkey, tt.extraDisk)
 			if err != nil && err != tt.err {
 				t.Errorf("expected error %v, got %v", tt.err, err)
 			}

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -2,11 +2,12 @@ package cluster
 
 // Node represents a Kubernetes node
 type NodeSpec struct {
-	Image      Image `json:"image"`
-	MemoryGB   int   `json:"memoryGB"`
-	CPUCount   int   `json:"cpuCount"`
-	DiskSize   int   `json:"diskSize"`
-	ExternalIP bool  `json:"externalIP"`
+	Image         Image `json:"image"`
+	MemoryGB      int   `json:"memoryGB"`
+	CPUCount      int   `json:"cpuCount"`
+	RootDiskSize  int   `json:"diskSize"`
+	ExtraDiskSize int   `json:"extraDiskSize"`
+	ExternalIP    bool  `json:"externalIP"`
 }
 
 type Image struct {


### PR DESCRIPTION
Fixes #32 

Adds options to create an extra disk on workers and control plane. If requested size is 0 GB, then does not create extra disk.

We probably need to add something to cloudinit to format the disk and make it usable.