### PR TITLE
Fix disks

### DIFF
--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -20,19 +20,7 @@ const (
 )
 
 func CreateInstance(ctx context.Context, client *oxide.Client, projectID, instanceName string, spec NodeSpec, cloudConfig string) (*oxide.Instance, error) {
-	disks := []oxide.InstanceDiskAttachment{
-		{
-			Type: oxide.InstanceDiskAttachmentTypeCreate,
-			DiskSource: oxide.DiskSource{
-				Type:      oxide.DiskSourceTypeImage,
-				ImageId:   spec.Image.ID,
-				BlockSize: blockSize,
-			},
-			Size:        oxide.ByteCount(spec.RootDiskSize),
-			Name:        oxide.Name(instanceName),
-			Description: instanceName,
-		},
-	}
+	var disks []oxide.InstanceDiskAttachment
 	if spec.ExtraDiskSize > 0 {
 		disks = append(disks, oxide.InstanceDiskAttachment{
 			Type: oxide.InstanceDiskAttachmentTypeCreate,
@@ -54,6 +42,18 @@ func CreateInstance(ctx context.Context, client *oxide.Client, projectID, instan
 		NetworkInterfaces: oxide.InstanceNetworkInterfaceAttachment{
 			Type: "default",
 		},
+		BootDisk: &oxide.InstanceDiskAttachment{
+			Type: oxide.InstanceDiskAttachmentTypeCreate,
+			DiskSource: oxide.DiskSource{
+				Type:      oxide.DiskSourceTypeImage,
+				ImageId:   spec.Image.ID,
+				BlockSize: blockSize,
+			},
+			Size:        oxide.ByteCount(spec.RootDiskSize),
+			Name:        oxide.Name(instanceName),
+			Description: instanceName,
+		},
+
 		UserData: cloudConfig,
 		Disks:    disks,
 	}

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aifoundry-org/oxide-controller/pkg/util"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -20,8 +21,16 @@ const (
 )
 
 func CreateInstance(ctx context.Context, client *oxide.Client, projectID, instanceName string, spec NodeSpec, cloudConfig string) (*oxide.Instance, error) {
+	// every disk needs a unique name. Unfortunately, due to a bug in how
+	// the disks are provided a controller, if the first 20 characters are the same
+	// then you end up with controller conflicts.
+	// Until the bug is fixed, we will just add a random 8-character prefix to the name.
 	var disks []oxide.InstanceDiskAttachment
 	if spec.ExtraDiskSize > 0 {
+		prefix, err := util.RandomString(8, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate random string: %w", err)
+		}
 		disks = append(disks, oxide.InstanceDiskAttachment{
 			Type: oxide.InstanceDiskAttachmentTypeCreate,
 			DiskSource: oxide.DiskSource{
@@ -29,9 +38,13 @@ func CreateInstance(ctx context.Context, client *oxide.Client, projectID, instan
 				BlockSize: blockSize,
 			},
 			Size:        oxide.ByteCount(spec.ExtraDiskSize),
-			Name:        oxide.Name(instanceName + "-disk-1"),
+			Name:        oxide.Name(fmt.Sprintf("%s-%s-disk-1", prefix, instanceName)),
 			Description: instanceName,
 		})
+	}
+	prefix, err := util.RandomString(8, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate random string: %w", err)
 	}
 	createBody := &oxide.InstanceCreate{
 		Name:        oxide.Name(instanceName),
@@ -50,7 +63,7 @@ func CreateInstance(ctx context.Context, client *oxide.Client, projectID, instan
 				BlockSize: blockSize,
 			},
 			Size:        oxide.ByteCount(spec.RootDiskSize),
-			Name:        oxide.Name(instanceName),
+			Name:        oxide.Name(fmt.Sprintf("%s-%s", prefix, instanceName)),
 			Description: instanceName,
 		},
 


### PR DESCRIPTION
This does two things:

1. Restructure how disks are attached. Originally we used `RootDisk`. When extra disks were added, we saw conflicts on controller, so we switched to multiple `Disks` entries instead of `RootDisk`. Once we understood that the issue was not due to our usage of the API but a bug in how Oxide handles multiple disks, specifically where the names are identical for the first 20 characters, this PR switches back to using `RootDisk` and `Disks`.
2. Prefix all disk names with a random string of 8 characters. This should avoid any of the controller conflicts due to first 20 characters in the name, while keeping the name clear enough to identify what instance it is (or was) part of.

This still is missing the cloudinit to format the disk and mount it. That will come in a later PR.