### PR TITLE
leverage tailscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,8 @@ the new information.
 
 ## tailscale
 
-If you provide a tailscale auth key, as part of the configuration, or the path to a key, the
-oxide-controller will install tailscale on every node on the cluster, and join it to a tailnet
-with the provided auth key. This is useful for accessing the nodes from outside the cluster, without
-using public IP addresses.
+The oxide-controller can optionally install tailscale on the nodes in the cluster. This is
+useful for accessing the nodes from outside the cluster, in addition to or in exchange for
+using the public IP addresses.
 
-By default, the nodes will join with the tailscale tag `ainekko-k8s-node`. You can override it
-using CLI flags. The tag *must* be a valid tailscale tag in your tailnet.
+See [tailscale.md](./docs/tailscale.md) for more information on how to set up tailscale.

--- a/docs/tailscale.md
+++ b/docs/tailscale.md
@@ -1,0 +1,45 @@
+# Tailscale
+
+If you want to use tailscale to access the nodes in the cluster,
+in addition to or in exchange of the public IPs, you can have each node register with a
+tailnet.
+
+## Prerequisites
+
+- A tailscale account
+- A tailnet
+- Appropriate tags for the nodes. By default this is `ainekko-k8s-node`.
+- A tailscale [auth key](https://tailscale.com/kb/1085/auth-keys) with rights to join nodes for the provided tags. The key should be ephemeral and reusable.
+- A tailscale API key, also known as an access token, with rights to list nodes.
+
+## Requirements
+
+If you want to use tailscale, you **must** provide all of:
+
+* auth key - so nodes can join the tailnet
+* API key - so the controller can list the nodes in the tailnet and retrieve the IP address of the first node
+* tailnet - so the controller can know which nodes to list
+
+## How it works
+
+When you provide the controller with the tailscale auth key and API key, it will:
+
+1. Install tailscale on each node in the cluster
+1. Register the node using the auth key, thus joining the tailnet for that auth key, with the provided tags
+1. Use the tailscale API with the API key to list the nodes in the tailnet and retrieve the IP address of the first node
+1. Use the IP address of the first node to connect to the node, retrieve the join token and kubeconfig
+
+## Default Tag
+
+The default tag used is `ainekko-k8s-controller`. This must exist in your tailnet's ACLs.
+You can override this tag using the `--tailscale-tag` flag.
+
+## Security considerations
+
+The auth key is stored in the following places:
+
+* The `kube-system/oxide-controller` secret in the cluster
+* cloud-config of each node
+
+The API key is not stored at all. It is used locally exactly once to retrieve the IP address of the
+first node and then discarded.

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/tailscale/hujson v0.0.0-20220506213045-af5ed07155e5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
@@ -56,4 +57,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
+	tailscale.com/client/tailscale/v2 v2.0.0-20250509161557-5fad10cf3a33 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tailscale/hujson v0.0.0-20220506213045-af5ed07155e5 h1:erxeiTyq+nw4Cz5+hLDkOwNF5/9IQWCQPv0gpb3+QHU=
+github.com/tailscale/hujson v0.0.0-20220506213045-af5ed07155e5/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -174,3 +176,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.2 h1:MdmvkGuXi/8io6ixD5wud3vOLwc1rj0aN
 sigs.k8s.io/structured-merge-diff/v4 v4.4.2/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
+tailscale.com/client/tailscale/v2 v2.0.0-20250509161557-5fad10cf3a33 h1:ZhAYOHl/OZyBiFKfW7jddphk82XSsEtgAj2nwTGlKvQ=
+tailscale.com/client/tailscale/v2 v2.0.0-20250509161557-5fad10cf3a33/go.mod h1:nzqx3Hs59z2W8Gnmq2ChavPButcyvtxAxRpNc+ZVy7s=


### PR DESCRIPTION
* Updates the docs to have an explicit tailscale page
* fixes some tailscale issues
* retrieves the tailnet from the API and uses that to connect to the control plane node, and inject into kubeconfig

There still is no option not to use a floating IP, but with this in place, we could remove it in the future.

Load balancing is an open question, but one step at a time.