### PR TITLE
silence usage after checking CLI flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -155,9 +155,9 @@ func rootCmd() (*cobra.Command, error) {
 				}
 			}
 
-			// At this point that we should set cmd.ShowUsage = false, as we no longer need to show the usage.
+			// At this point that we set cmd.SilenceUsage = true, as we no longer need to show the usage.
 			// All future errors are by the system, not erroneous user input.
-			// We will do it in a separate commit.
+			cmd.SilenceUsage = true
 
 			ctx := context.Background()
 


### PR DESCRIPTION
Any errors in the program eventually bubble up to returning an error in cobra `RunE()`. By default, cobra treats this as "report the error and then show usage."

However, this only is correct behaviour if the error is due to misused flags, or flags that refer to bad information. If the error occurs after a certain point, it has nothing to do with usage. We disable showing the usage after that point.