### PR TITLE
Oxide token management

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -43,15 +43,10 @@ type Cluster struct {
 }
 
 // New creates a new Cluster instance
-func New(logger *log.Entry, oxideURL, oxideToken, projectID string, controlPlanePrefix, workerPrefix string, controlPlaneCount, workerCount int, controlPlaneSpec, workerSpec NodeSpec, imageParallelism int, namespace, secretName string, kubeconfig, pubkey []byte, clusterInitWait time.Duration, kubeconfigOverwrite bool, tailscaleAPIKey, tailscaleTailnet, OCIimage string) *Cluster {
-	cfg := oxide.Config{
-		Host:  oxideURL,
-		Token: string(oxideToken),
-	}
-
+func New(logger *log.Entry, oxideConfig *oxide.Config, projectID string, controlPlanePrefix, workerPrefix string, controlPlaneCount, workerCount int, controlPlaneSpec, workerSpec NodeSpec, imageParallelism int, namespace, secretName string, kubeconfig, pubkey []byte, clusterInitWait time.Duration, kubeconfigOverwrite bool, tailscaleAPIKey, tailscaleTailnet, OCIimage string) *Cluster {
 	c := &Cluster{
 		logger:              logger.WithField("component", "cluster"),
-		oxideConfig:         &cfg,
+		oxideConfig:         oxideConfig,
 		projectID:           projectID,
 		controlPlanePrefix:  controlPlanePrefix,
 		workerPrefix:        workerPrefix,

--- a/pkg/cluster/const.go
+++ b/pkg/cluster/const.go
@@ -12,6 +12,8 @@ const (
 	secretKeySystemSSHPublic  = "system-ssh-public-key"
 	secretKeySystemSSHPrivate = "system-ssh-private-key"
 	secretKeyWorkerCount      = "worker-count"
+	secretKeyOxideToken       = "oxide-token"
+	secretKeyOxideURL         = "oxide-url"
 	maximumChunkSize          = 512 * KB
 
 	devModeOCIImage = "dev"

--- a/pkg/cluster/exec.go
+++ b/pkg/cluster/exec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/aifoundry-org/oxide-controller/pkg/util"
+	"github.com/oxidecomputer/oxide.go/oxide"
 )
 
 // Execute execute the core functionality, which includes:
@@ -14,8 +15,12 @@ import (
 // 4. Ensuring the worker nodes exist as desired
 // 5. Returning the new kubeconfig, if any
 func (c *Cluster) Execute(ctx context.Context) (newKubeconfig []byte, err error) {
+	client, err := oxide.NewClient(c.oxideConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Oxide API client: %v", err)
+	}
 
-	projectID, err := ensureProjectExists(ctx, c.logger, c.client, c.projectID)
+	projectID, err := ensureProjectExists(ctx, c.logger, client, c.projectID)
 	if err != nil {
 		return nil, fmt.Errorf("project verification failed: %v", err)
 	}
@@ -24,7 +29,7 @@ func (c *Cluster) Execute(ctx context.Context) (newKubeconfig []byte, err error)
 		c.logger.Infof("Using project ID: %s", c.projectID)
 	}
 
-	images, err := ensureImagesExist(ctx, c.logger, c.client, c.projectID, c.imageParallelism, c.controlPlaneSpec.Image, c.workerSpec.Image)
+	images, err := ensureImagesExist(ctx, c.logger, client, c.projectID, c.imageParallelism, c.controlPlaneSpec.Image, c.workerSpec.Image)
 	if err != nil {
 		return nil, fmt.Errorf("image verification failed: %v", err)
 	}

--- a/pkg/oxide/profile.go
+++ b/pkg/oxide/profile.go
@@ -1,0 +1,100 @@
+package oxide
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/pelletier/go-toml"
+)
+
+// everything in this file is a duplicate of the code in oxide.go, but
+// all of that is private, and we need to be able to get the actual token and host
+// to store in the cluster secret, so we had to duplicate it here.
+// When that becomes public, or if they create service accounts on oxide,
+// we can remove this code.
+
+const (
+	defaultConfigDir string = ".config/oxide"
+	configFile       string = "config.toml"
+	credentialsFile  string = "credentials.toml"
+)
+
+func GetProfile(cfg *oxide.Config) (string, string, error) {
+	configDir := cfg.ConfigDir
+	if configDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", "", fmt.Errorf("unable to find user's home directory: %w", err)
+		}
+		configDir = filepath.Join(homeDir, defaultConfigDir)
+	}
+
+	profile := cfg.Profile
+
+	// Use explicitly configured profile over default when both are set.
+	if cfg.UseDefaultProfile && profile == "" {
+		configPath := filepath.Join(configDir, configFile)
+
+		var err error
+		profile, err = defaultProfile(configPath)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to get default profile from %q: %w", configPath, err)
+		}
+	}
+
+	credentialsPath := filepath.Join(configDir, credentialsFile)
+	host, token, err := parseCredentialsFile(credentialsPath, profile)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get credentials for profile %q from %q: %w", profile, credentialsPath, err)
+	}
+
+	return host, token, nil
+}
+
+// defaultProfile returns the default profile from config.toml, if present.
+func defaultProfile(configPath string) (string, error) {
+	configFile, err := toml.LoadFile(configPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open config: %w", err)
+	}
+
+	if profileName := configFile.Get("default-profile"); profileName != nil {
+		return profileName.(string), nil
+	}
+
+	return "", errors.New("no default profile set")
+}
+
+// parseCredentialsFile parses a credentials.toml and returns the token and host
+// associated with the requested profile.
+func parseCredentialsFile(credentialsPath, profileName string) (string, string, error) {
+	if profileName == "" {
+		return "", "", errors.New("no profile name provided")
+	}
+
+	credentialsFile, err := toml.LoadFile(credentialsPath)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to open %q: %v", credentialsPath, err)
+	}
+
+	profile, ok := credentialsFile.Get("profile." + profileName).(*toml.Tree)
+	if !ok {
+		return "", "", errors.New("profile not found")
+	}
+
+	var hostTokenErr error
+	token, ok := profile.Get("token").(string)
+	if !ok {
+		hostTokenErr = errors.New("token not found")
+	}
+
+	host, ok := profile.Get("host").(string)
+	if !ok {
+		hostTokenErr = errors.Join(errors.New("host not found"))
+	}
+
+	return host, token, hostTokenErr
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -9,14 +9,12 @@ import (
 	"github.com/aifoundry-org/oxide-controller/pkg/cluster"
 	"github.com/gorilla/mux"
 
-	"github.com/oxidecomputer/oxide.go/oxide"
 	log "github.com/sirupsen/logrus"
 )
 
 type Server struct {
 	logger         *log.Entry
 	address        string
-	oxideClient    *oxide.Client
 	cluster        *cluster.Cluster
 	secretName     string
 	projectID      string
@@ -26,11 +24,10 @@ type Server struct {
 	workerCPUCount int
 }
 
-func New(address string, logger *log.Entry, oxideClient *oxide.Client, cluster *cluster.Cluster, secretName, projectID, prefix, workerImage string, workerMemoryGB, workerCPUCount int) *Server {
+func New(address string, logger *log.Entry, cluster *cluster.Cluster, secretName, projectID, prefix, workerImage string, workerMemoryGB, workerCPUCount int) *Server {
 	return &Server{
 		logger:         logger.WithField("component", "server"),
 		address:        address,
-		oxideClient:    oxideClient,
 		cluster:        cluster,
 		secretName:     secretName,
 		projectID:      projectID,


### PR DESCRIPTION
Adds support for profiles and default credentials and config files, matching what the SDK and CLI usually do. 

Saves them to secret in the cluster for future access.

Still missing reading it from secret when running in cluster. Next step.