### PR TITLE
determine k8s client source and use to find secret on startup

### DIFF
--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -37,6 +37,7 @@ spec:
           command: ["/controller"]
           args: 
           - --no-pivot=true
+          - --verbose={{ .Values.verbose }}
           ports:
             - containerPort: {{ .Values.image.port }}
           env:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,6 +2,7 @@ namespace: oxide-controller-system
 createNamespace: true
 secretName: oxide-controller-secret
 useHostBinary: false
+verbose: 0
 image:
   repository: aifoundryorg/oxide-controller
   tag: latest

--- a/pkg/cluster/client.go
+++ b/pkg/cluster/client.go
@@ -1,10 +1,25 @@
 package cluster
 
 import (
+	"fmt"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
+
+type ConfigSource int
+
+const (
+	ConfigSourceProvidedKubeconfig ConfigSource = iota
+	ConfigSourceDefaultKubeconfig
+	ConfigSourceInCluster
+)
+
+type Config struct {
+	*rest.Config
+	Source ConfigSource
+}
 
 // getClientset returns a Kubernetes clientset, optionally using raw kubeconfig data.
 // If kubeconfigRaw is nil or empty, it falls back to environment/default paths and in-cluster config.
@@ -18,26 +33,33 @@ func getClientset(config *rest.Config) (*kubernetes.Clientset, error) {
 	return clientset, nil
 }
 
-func getRestConfig(kubeconfigRaw []byte) (*rest.Config, error) {
+func GetRestConfig(kubeconfigRaw []byte) (*Config, error) {
 	if len(kubeconfigRaw) > 0 {
+		fmt.Println("Using provided kubeconfig")
 		configAPI, err := clientcmd.Load(kubeconfigRaw)
 		if err != nil {
 			return nil, err
 		}
 		clientConfig := clientcmd.NewDefaultClientConfig(*configAPI, &clientcmd.ConfigOverrides{})
-		return clientConfig.ClientConfig()
+		conf, err := clientConfig.ClientConfig()
+		return &Config{Config: conf, Source: ConfigSourceProvidedKubeconfig}, err
+	}
+	// try in-cluster
+	conf, err := rest.InClusterConfig()
+	fmt.Printf("Using in-cluster err: %v\n", err)
+	fmt.Printf("Using in-cluster config: %+v\n", conf)
+	if err == nil {
+		return &Config{Config: conf, Source: ConfigSourceInCluster}, err
 	}
 
-	// Try local default config first
+	// fall back to default config
+	fmt.Println("Trying default kubeconfig")
 	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(),
 		&clientcmd.ConfigOverrides{},
 	)
 	config, err := kubeconfig.ClientConfig()
-	if err == nil {
-		return config, nil
-	}
-
-	// Fall back to in-cluster
-	return rest.InClusterConfig()
+	fmt.Printf("Using default kubeconfig err: %v\n", err)
+	fmt.Printf("Using default kubeconfig config: %+v\n", config)
+	return &Config{Config: config, Source: ConfigSourceDefaultKubeconfig}, err
 }

--- a/pkg/cluster/const.go
+++ b/pkg/cluster/const.go
@@ -16,5 +16,6 @@ const (
 	secretKeyOxideURL         = "oxide-url"
 	maximumChunkSize          = 512 * KB
 
-	devModeOCIImage = "dev"
+	devModeOCIImage  = "dev"
+	utilityImageName = "alpine:3.21"
 )

--- a/pkg/cluster/copy.go
+++ b/pkg/cluster/copy.go
@@ -36,7 +36,7 @@ func (c *Cluster) LoadControllerToClusterNodes(ctx context.Context, infile io.Re
 	if err := deployPreloadBinaryDaemonSet(c.clientset, c.namespace, preloadBinaryName, labels); err != nil {
 		return fmt.Errorf("deploying preload-binary DaemonSet: %w", err)
 	}
-	if err := copyToAllDaemonSetPods(c.clientset, c.apiConfig, c.namespace, fmt.Sprintf("%s=%s", labelKey, labelValue), "writer", filepath.Join(containerDir, binaryName), infile); err != nil {
+	if err := copyToAllDaemonSetPods(c.clientset, c.apiConfig.Config, c.namespace, fmt.Sprintf("%s=%s", labelKey, labelValue), "writer", filepath.Join(containerDir, binaryName), infile); err != nil {
 		return fmt.Errorf("copying to all DaemonSet pods: %w", err)
 	}
 	if err := removePreloadBinaryDaemonSet(c.clientset, c.namespace, preloadBinaryName); err != nil {
@@ -165,7 +165,7 @@ func deployPreloadBinaryDaemonSet(clientset *kubernetes.Clientset, namespace, na
 					Containers: []corev1.Container{
 						{
 							Name:    "writer",
-							Image:   "busybox",
+							Image:   utilityImageName,
 							Command: []string{"sh", "-c", "sleep 3600"},
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/pkg/cluster/secret.go
+++ b/pkg/cluster/secret.go
@@ -31,7 +31,7 @@ func getSecretValue(ctx context.Context, apiConfig *rest.Config, logger *log.Ent
 
 // GetJoinToken retrieves a new k3s worker join token from the Kubernetes cluster
 func (c *Cluster) GetJoinToken(ctx context.Context) (string, error) {
-	value, err := getSecretValue(ctx, c.apiConfig, c.logger, c.namespace, c.secretName, secretKeyJoinToken)
+	value, err := getSecretValue(ctx, c.apiConfig.Config, c.logger, c.namespace, c.secretName, secretKeyJoinToken)
 	if err != nil {
 		return "", err
 	}
@@ -43,7 +43,25 @@ func (c *Cluster) GetJoinToken(ctx context.Context) (string, error) {
 
 // GetUserSSHPublicKey retrieves the SSH public key from the Kubernetes cluster
 func (c *Cluster) GetUserSSHPublicKey(ctx context.Context) ([]byte, error) {
-	pubkey, err := getSecretValue(ctx, c.apiConfig, c.logger, c.namespace, c.secretName, secretKeyUserSSH)
+	pubkey, err := getSecretValue(ctx, c.apiConfig.Config, c.logger, c.namespace, c.secretName, secretKeyUserSSH)
+	if err != nil {
+		return nil, err
+	}
+	return pubkey, nil
+}
+
+// GetOxideToken retrieves the oxide token from the Kubernetes cluster
+func (c *Cluster) GetOxideToken(ctx context.Context) ([]byte, error) {
+	pubkey, err := getSecretValue(ctx, c.apiConfig.Config, c.logger, c.namespace, c.secretName, secretKeyOxideToken)
+	if err != nil {
+		return nil, err
+	}
+	return pubkey, nil
+}
+
+// GetOxideURL retrieves the oxide URL from the Kubernetes cluster
+func (c *Cluster) GetOxideURL(ctx context.Context) ([]byte, error) {
+	pubkey, err := getSecretValue(ctx, c.apiConfig.Config, c.logger, c.namespace, c.secretName, secretKeyOxideURL)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +70,7 @@ func (c *Cluster) GetUserSSHPublicKey(ctx context.Context) ([]byte, error) {
 
 // GetWorkerCount retrieves the targeted worker count from the Kubernetes cluster
 func (c *Cluster) GetWorkerCount(ctx context.Context) (int, error) {
-	workerCount, err := getSecretValue(ctx, c.apiConfig, c.logger, c.namespace, c.secretName, secretKeyWorkerCount)
+	workerCount, err := getSecretValue(ctx, c.apiConfig.Config, c.logger, c.namespace, c.secretName, secretKeyWorkerCount)
 	if err != nil {
 		return 0, err
 	}
@@ -70,7 +88,7 @@ func (c *Cluster) GetWorkerCount(ctx context.Context) (int, error) {
 
 // SetWorkerCount sets the targeted worker count in the Kubernetes cluster
 func (c *Cluster) SetWorkerCount(ctx context.Context, count int) error {
-	secretMap, err := getSecret(ctx, c.apiConfig, c.logger, c.namespace, c.secretName)
+	secretMap, err := getSecret(ctx, c.apiConfig.Config, c.logger, c.namespace, c.secretName)
 	if err != nil {
 		return fmt.Errorf("failed to get secret: %w", err)
 	}
@@ -79,6 +97,24 @@ func (c *Cluster) SetWorkerCount(ctx context.Context, count int) error {
 		return fmt.Errorf("failed to save secret: %w", err)
 	}
 	return nil
+}
+
+// GetOxideToken retrieves the oxide token from the Kubernetes cluster
+func GetOxideToken(ctx context.Context, restConfig *rest.Config, logger *log.Entry, namespace, secretName string) ([]byte, error) {
+	pubkey, err := getSecretValue(ctx, restConfig, logger, namespace, secretName, secretKeyOxideToken)
+	if err != nil {
+		return nil, err
+	}
+	return pubkey, nil
+}
+
+// GetOxideURL retrieves the oxide URL from the Kubernetes cluster
+func GetOxideURL(ctx context.Context, restConfig *rest.Config, logger *log.Entry, namespace, secretName string) ([]byte, error) {
+	pubkey, err := getSecretValue(ctx, restConfig, logger, namespace, secretName, secretKeyOxideURL)
+	if err != nil {
+		return nil, err
+	}
+	return pubkey, nil
 }
 
 // getSecret gets the secret with all of our important information

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,0 +1,34 @@
+package log
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+func GetLevel(verbose int) log.Level {
+	var level log.Level
+	switch verbose {
+	case 0:
+		level = log.InfoLevel
+	case 1:
+		level = log.DebugLevel
+	case 2:
+		level = log.TraceLevel
+	default:
+		level = log.InfoLevel
+
+	}
+	return level
+}
+
+func GetFlag(level log.Level) int {
+	var verbose int
+	switch level {
+	case log.DebugLevel:
+		verbose = 1
+	case log.TraceLevel:
+		verbose = 2
+	default:
+		verbose = 0
+	}
+	return verbose
+}


### PR DESCRIPTION
Also:

* saves oxide info in cluster secret and retrieves it correctly.
* runs in-cluster with the same debug level as the initial binary run.
* leverages oxide client to retrieve credentials using same profile files as the CLI

There still are more things to reconcile for in-cluster, the other passed parameters. Those will come in future PRs.